### PR TITLE
ci: removed private property in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@salable/node-sdk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@salable/node-sdk",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^17.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@salable/node-sdk",
   "version": "1.3.0",
-  "private": true,
   "description": "Node.js SDK to interact with Salable APIs",
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
Removes the `private` property from the `package.json` file to allow for publishing to NPM