### PR TITLE
feat: setup stripe test data function + set up prisma

### DIFF
--- a/__tests__/_setup/setup-test-envs.ts
+++ b/__tests__/_setup/setup-test-envs.ts
@@ -1,3 +1,36 @@
 import { config } from 'dotenv';
+import createStripeData from '../../test-utils/stripe/create-stripe-test-data';
+
+(async () => {
+    const stripeEnvVariables = await createStripeData();
+    process.env = {
+        ...process.env,
+        STRIPE_PAYMENT_METHOD_ID: stripeEnvVariables.stripePaymentMethodId,
+        STRIPE_CUSTOMER_ID: stripeEnvVariables.stripeCustomerId,
+        STRIPE_PRODUCT_WIDGET_ONE_ID: stripeEnvVariables.stripeProductWidgetOneId,
+        STRIPE_PLAN_BASIC_MONTHLY_GBP_ID: stripeEnvVariables.stripePlanBasicMonthlyGbpId,
+        STRIPE_PLAN_BASIC_YEARLY_GBP_ID: stripeEnvVariables.stripePlanBasicYearlyGbpId,
+        STRIPE_PLAN_PER_SEAT_UNLIMITED_MONTHLY_GBP_ID: stripeEnvVariables.stripePlanPerSeatUnlimitedMonthlyGbpId,
+        STRIPE_PLAN_PER_SEAT_MAXIMUM_MONTHLY_GBP_ID: stripeEnvVariables.stripePlanPerSeatMaximumMonthlyGbpId,
+        STRIPE_PLAN_PER_SEAT_RANGE_MONTHLY_GBP_ID: stripeEnvVariables.stripePlanPerSeatRangeMonthlyGbpId,
+        STRIPE_PLAN_PER_SEAT_MINIMUM_MONTHLY_GBP_ID: stripeEnvVariables.stripePlanPerSeatMinimumMonthlyGbpId,
+        STRIPE_PLAN_PER_SEAT_BASIC_MONTHLY_GBP_ID: stripeEnvVariables.stripePlanPerSeatBasicMonthlyGbpId,
+        STRIPE_PLAN_USAGE_PRO_MONTHLY_GBP_ID: stripeEnvVariables.stripePlanUsageProMonthlyGbpId,
+        STRIPE_PLAN_USAGE_BASIC_MONTHLY_GBP_ID: stripeEnvVariables.stripePlanUsageBasicMonthlyGbpId,
+        STRIPE_PLAN_PRO_MONTHLY_GBP_ID: stripeEnvVariables.stripePlanProMonthlyGbpId,
+        STRIPE_PLAN_BASIC_MONTHLY_USD_ID: stripeEnvVariables.stripePlanBasicMonthlyUsdId,
+        STRIPE_PLAN_PRO_MONTHLY_USD_ID: stripeEnvVariables.stripePlanProMonthlyUsdId,
+        STRIPE_BASIC_SUBSCRIPTION_ID: stripeEnvVariables.stripeBasicSubscriptionId,
+        STRIPE_BASIC_SUBSCRIPTION_ID_TWO: stripeEnvVariables.stripeBasicSubscriptionIdTwo,
+        STRIPE_BASIC_SUBSCRIPTION_LINE_ITEM_ID: stripeEnvVariables.stripeBasicSubscriptionLineItemId,
+        STRIPE_BASIC_SUBSCRIPTION_TWO_LINE_ITEM_ID: stripeEnvVariables.stripeBasicSubscriptionTwoLineItemId,
+        STRIPE_PER_SEAT_BASIC_SUBSCRIPTION_ID: stripeEnvVariables.stripePerSeatBasicSubscriptionId,
+        STRIPE_PER_SEAT_BASIC_SUBSCRIPTION_LINE_ITEM_ID: stripeEnvVariables.stripePerSeatBasicSubscriptionLineItemId,
+        STRIPE_USAGE_BASIC_SUBSCRIPTION_ID: stripeEnvVariables.stripeUsageBasicSubscriptionId,
+        STRIPE_USAGE_BASIC_SUBSCRIPTION_LINE_ITEM_ID: stripeEnvVariables.stripeUsageBasicSubscriptionLineItemId,
+        STRIPE_PRO_SUBSCRIPTION_ID: stripeEnvVariables.stripeProSubscriptionId,
+        STRIPE_PRO_SUBSCRIPTION_LINE_ITEM_ID: stripeEnvVariables.stripeProSubscriptionLineItemId,
+    };
+})();
 
 config({ path: '.env.test' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@commitlint/cli": "^17.1.2",
         "@commitlint/config-conventional": "^17.1.0",
         "@eslint/js": "^9.13.0",
+        "@prisma/client": "^5.21.1",
         "@rollup/plugin-commonjs": "^28.0.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-replace": "^5.0.1",
@@ -2358,6 +2359,25 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "5.21.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.21.1.tgz",
+      "integrity": "sha512-3n+GgbAZYjaS/k0M03yQsQfR1APbr411r74foknnsGpmhNKBG49VuUkxIU6jORgvJPChoD4WC4PqoHImN1FP0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
       }
     },
     "node_modules/@prisma/debug": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
     "@eslint/js": "^9.13.0",
+    "@prisma/client": "^5.21.1",
     "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-replace": "^5.0.1",

--- a/test-utils/prisma/prisma-client.ts
+++ b/test-utils/prisma/prisma-client.ts
@@ -1,0 +1,35 @@
+import { PrismaClient } from '@prisma/client'
+
+const prismaClient = new PrismaClient({
+    datasources: { db: { url: process.env.DATABASE_URL } }
+});
+
+export default prismaClient;
+
+export const prismaClientWithLogs = new PrismaClient({
+    datasources: { db: { url: process.env.DATABASE_URL } },
+    log: [
+        {
+            emit: 'event',
+            level: 'query',
+        },
+        {
+            emit: 'stdout',
+            level: 'error',
+        },
+        {
+            emit: 'stdout',
+            level: 'info',
+        },
+        {
+            emit: 'stdout',
+            level: 'warn',
+        },
+    ],
+});
+
+prismaClientWithLogs.$on('query', (e) => {
+    console.log('Query: ' + e.query);
+    console.log('Params: ' + e.params);
+    console.log('Duration: ' + e.duration + 'ms')
+});

--- a/test-utils/stripe/create-stripe-custom-account.ts
+++ b/test-utils/stripe/create-stripe-custom-account.ts
@@ -1,0 +1,150 @@
+import Stripe from "stripe";
+
+const STRIPE_KEY = process.env.STRIPE_KEY;
+
+export default async function createStripeCustomAccount() {
+    const stripe = new Stripe(STRIPE_KEY!, {apiVersion: "2024-09-30.acacia"});
+
+    let account = await stripe.accounts.create({
+        country: 'US',
+        type: 'custom',
+        business_type: 'company',
+        capabilities: {
+            card_payments: {
+                requested: true,
+            },
+            transfers: {
+                requested: true,
+            },
+        },
+        external_account: 'btok_us',
+        tos_acceptance: {
+            service_agreement: 'full',
+            date: 1547923073,
+            ip: '172.18.80.19',
+        },
+    });
+
+    account = await stripe.accounts.update(
+        account.id,
+        {
+            business_profile: {
+                mcc: '5045',
+                url: 'https://bestcookieco.com',
+            },
+            company: {
+                address: {
+                    city: 'Schenectady',
+                    line1: 'address_full_match',
+                    postal_code: '12345',
+                    state: 'NY',
+                },
+                tax_id: '000000000',
+                name: 'The Best Cookie Co',
+                phone: '8888675309',
+            },
+        }
+    );
+
+    let representative = await stripe.accounts.createPerson(
+        account.id,
+        {
+            first_name: 'Jenny',
+            last_name: 'Rosen',
+            relationship: {
+                representative: true,
+                title: 'CEO',
+            },
+        }
+    );
+
+    representative = await stripe.accounts.updatePerson(
+        account.id,
+        representative.id,
+        {
+            address: {
+                city: 'Schenectady',
+                line1: 'address_full_match',
+                postal_code: '12345',
+                state: 'NY',
+            },
+            dob: {
+                day: 1,
+                month: 1,
+                year: 1902,
+            },
+            ssn_last_4: '0000',
+            phone: '8888675309',
+            email: 'jenny@bestcookieco.com',
+            relationship: {
+                executive: true,
+            },
+            id_number: '000-00-0000'
+        }
+    );
+
+    let owner = await stripe.accounts.createPerson(
+        account.id,
+        {
+            first_name: 'Kathleen',
+            last_name: 'Banks',
+            email: 'kathleen@bestcookieco.com',
+            relationship: {
+                owner: true,
+                percent_ownership: 80,
+            },
+            id_number: '000-00-0000'
+        }
+    );
+
+    owner = await stripe.accounts.updatePerson(
+        account.id,
+        owner.id,
+        {
+            address: {
+                city: 'Schenectady',
+                line1: 'address_full_match',
+                postal_code: '12345',
+                state: 'NY',
+            },
+            dob: {
+                day: 1,
+                month: 1,
+                year: 1902,
+            },
+            ssn_last_4: '0000',
+            phone: '8888675309',
+            email: 'kathleen@bestcookieco.com',
+            relationship: {
+                owner: true,
+                percent_ownership: 80,
+            },
+        }
+    );
+
+    account = await stripe.accounts.update(
+        account.id,
+        {
+            company: {
+                owners_provided: true,
+            },
+        }
+    );
+
+    const stripeConnect = new Stripe(STRIPE_KEY!, {
+        apiVersion: "2024-09-30.acacia",
+        stripeAccount: account.id
+    });
+
+    // Note: poll account until stripe has completed account verification
+    while (true) {
+        const connectedAccount = await stripeConnect.accounts.retrieve();
+        console.log('Pending requirements: ', connectedAccount.requirements?.pending_verification?.length);
+        if (connectedAccount.requirements?.pending_verification?.length === 0) break;
+        await new Promise(r => setTimeout(r, 2000));
+    }
+
+    console.log('Account ID:', account.id);
+
+    return account;
+}

--- a/test-utils/stripe/create-stripe-test-data.ts
+++ b/test-utils/stripe/create-stripe-test-data.ts
@@ -1,0 +1,355 @@
+import Stripe from "stripe";
+import createStripeCustomAccount from '../../test-utils/stripe/create-stripe-custom-account'
+
+const STRIPE_KEY = process.env.STRIPE_KEY;
+let STRIPE_ACCOUNT_ID = process.env.STRIPE_ACCOUNT_ID || null;
+
+export default async function createStripeData() {
+  if (!STRIPE_KEY) throw new Error('Missing STRIPE_KEY');
+
+  const stripeCustomerEmail = 'tester@domain.com';
+
+  type StripeData = {
+    stripePaymentMethodId: string,
+    stripeCustomerId: string,
+    stripeProductWidgetOneId: string,
+    stripePlanBasicMonthlyGbpId: string,
+    stripePlanBasicYearlyGbpId: string,
+    stripePlanPerSeatBasicMonthlyGbpId: string,
+    stripePlanUsageProMonthlyGbpId: string,
+    stripePlanUsageBasicMonthlyGbpId: string,
+    stripeUsageBasicSubscriptionLineItemId: string,
+    stripeUsageBasicSubscriptionId: string,
+    stripePlanProMonthlyGbpId: string,
+    stripePlanBasicMonthlyUsdId: string,
+    stripePlanProMonthlyUsdId: string,
+    stripeBasicSubscriptionId: string,
+    stripeBasicSubscriptionIdTwo: string,
+    stripeBasicSubscriptionLineItemId: string,
+    stripeBasicSubscriptionTwoLineItemId: string,
+    stripePerSeatBasicSubscriptionId: string,
+    stripePerSeatBasicSubscriptionLineItemId: string,
+    stripeProSubscriptionId: string,
+    stripeProSubscriptionLineItemId: string,
+    stripePlanPerSeatUnlimitedMonthlyGbpId: string,
+    stripePlanPerSeatMaximumMonthlyGbpId: string,
+    stripePlanPerSeatMinimumMonthlyGbpId: string,
+    stripePlanPerSeatRangeMonthlyGbpId: string,
+  }
+
+  const obj: StripeData = {
+    stripePaymentMethodId: '',
+    stripeCustomerId: '',
+    stripeProductWidgetOneId: '',
+    stripePlanBasicMonthlyGbpId: '',
+    stripePlanBasicYearlyGbpId: '',
+    stripeUsageBasicSubscriptionLineItemId: '',
+    stripeUsageBasicSubscriptionId: '',
+    stripePlanPerSeatBasicMonthlyGbpId: '',
+    stripePlanUsageBasicMonthlyGbpId: '',
+    stripePlanUsageProMonthlyGbpId: '',
+    stripePlanProMonthlyGbpId: '',
+    stripePlanBasicMonthlyUsdId: '',
+    stripePlanProMonthlyUsdId: '',
+    stripeBasicSubscriptionId: '',
+    stripeBasicSubscriptionIdTwo: '',
+    stripeBasicSubscriptionLineItemId: '',
+    stripeBasicSubscriptionTwoLineItemId: '',
+    stripePerSeatBasicSubscriptionId: '',
+    stripePerSeatBasicSubscriptionLineItemId: '',
+    stripeProSubscriptionId: '',
+    stripeProSubscriptionLineItemId: '',
+    stripePlanPerSeatUnlimitedMonthlyGbpId: '',
+    stripePlanPerSeatMaximumMonthlyGbpId: '',
+    stripePlanPerSeatMinimumMonthlyGbpId: '',
+    stripePlanPerSeatRangeMonthlyGbpId: '',
+  };
+
+  if (!STRIPE_ACCOUNT_ID) {
+    const account = await createStripeCustomAccount();
+    STRIPE_ACCOUNT_ID = account.id;
+  }
+
+  const stripeConnect = new Stripe(STRIPE_KEY, {
+    apiVersion: "2024-09-30.acacia",
+    stripeAccount: STRIPE_ACCOUNT_ID
+  });
+
+  if (!obj.stripePaymentMethodId) {
+    const stripePaymentMethod = await stripeConnect.paymentMethods.create({
+      type: 'card',
+      card: { token: 'tok_visa' } as Stripe.PaymentMethodCreateParams.Card,
+    });
+    console.log('CREATED stripePaymentMethod');
+    obj.stripePaymentMethodId = stripePaymentMethod.id
+  }
+
+  if (!obj.stripeCustomerId) {
+    const stripeCustomer = await stripeConnect.customers.create({
+      email: stripeCustomerEmail,
+      payment_method: obj.stripePaymentMethodId
+    });
+    console.log('CREATED stripeCustomer');
+    obj.stripeCustomerId = stripeCustomer.id
+  }
+
+  if (!obj.stripeProductWidgetOneId) {
+    const stripeProductWidgetOne = await stripeConnect.products.create({
+      name: 'Widget One',
+    });
+    console.log('CREATED stripeProductWidgetOne');
+    obj.stripeProductWidgetOneId = stripeProductWidgetOne.id
+  }
+
+  if (!obj.stripePlanUsageProMonthlyGbpId) {
+    const stripePlanUsageProMonthlyGbp = await stripeConnect.plans.create({
+      nickname: 'Usage Basic',
+      currency: "gbp",
+      interval: "month",
+      product: obj.stripeProductWidgetOneId,
+      amount: 50,
+      usage_type: 'metered'
+    });
+    console.log('CREATED stripePlanUsageProMonthlyGbpId');
+    obj.stripePlanUsageProMonthlyGbpId = stripePlanUsageProMonthlyGbp.id
+  }
+
+  if (!obj.stripePlanUsageBasicMonthlyGbpId) {
+    const stripePlanUsageBasicMonthlyGbp = await stripeConnect.plans.create({
+      nickname: 'Usage Basic',
+      currency: "gbp",
+      interval: "month",
+      product: obj.stripeProductWidgetOneId,
+      amount: 20,
+      usage_type: 'metered'
+    });
+    console.log('CREATED stripePlanUsageBasicMonthlyGbp');
+    obj.stripePlanUsageBasicMonthlyGbpId = stripePlanUsageBasicMonthlyGbp.id
+  }
+
+  if (!obj.stripeUsageBasicSubscriptionId) {
+    const stripeUsageBasicSubscription = await stripeConnect.subscriptions.create({
+      customer: obj.stripeCustomerId,
+      items: [{
+        price: obj.stripePlanUsageBasicMonthlyGbpId
+      }],
+      default_payment_method: obj.stripePaymentMethodId
+    });
+    console.log('CREATED stripeUsageBasicSubscription');
+    obj.stripeUsageBasicSubscriptionId = stripeUsageBasicSubscription.id;
+    obj.stripeUsageBasicSubscriptionLineItemId = stripeUsageBasicSubscription.items.data[0].id
+  }
+
+  if (!obj.stripePlanPerSeatBasicMonthlyGbpId) {
+    const stripePlanPerSeatBasicMonthlyGbp = await stripeConnect.plans.create({
+      nickname: 'Per Seat Basic',
+      currency: "gbp",
+      interval: "month",
+      product: obj.stripeProductWidgetOneId,
+      amount: 1500
+    });
+    console.log('CREATED stripePlanPerSeatBasicMonthlyGbp');
+    obj.stripePlanPerSeatBasicMonthlyGbpId = stripePlanPerSeatBasicMonthlyGbp.id
+  }
+
+  if (!obj.stripePlanPerSeatUnlimitedMonthlyGbpId) {
+    const stripePlanPerSeatUnlimitedMonthlyGbp = await stripeConnect.plans.create({
+      nickname: 'Per Seat Unlimited',
+      currency: "gbp",
+      interval: "month",
+      product: obj.stripeProductWidgetOneId,
+      amount: 100
+    });
+    console.log('CREATED stripePlanPerSeatUnlimitedMonthlyGbp');
+    obj.stripePlanPerSeatUnlimitedMonthlyGbpId = stripePlanPerSeatUnlimitedMonthlyGbp.id
+  }
+
+  if (!obj.stripePlanPerSeatMaximumMonthlyGbpId) {
+    const stripePlanPerSeatMaximumMonthlyGbp = await stripeConnect.plans.create({
+      nickname: 'Per Seat Maximum',
+      currency: "gbp",
+      interval: "month",
+      product: obj.stripeProductWidgetOneId,
+      amount: 200
+    });
+    console.log('CREATED stripePlanPerSeatMaximumMonthlyGbp');
+    obj.stripePlanPerSeatMaximumMonthlyGbpId = stripePlanPerSeatMaximumMonthlyGbp.id
+  }
+
+  if (!obj.stripePlanPerSeatRangeMonthlyGbpId) {
+    const stripePlanPerSeatRangeMonthlyGbp = await stripeConnect.plans.create({
+      nickname: 'Per Seat Range',
+      currency: "gbp",
+      interval: "month",
+      product: obj.stripeProductWidgetOneId,
+      amount: 300
+    });
+    console.log('CREATED stripePlanPerSeatRangeMonthlyGbp');
+    obj.stripePlanPerSeatRangeMonthlyGbpId = stripePlanPerSeatRangeMonthlyGbp.id
+  }
+
+  if (!obj.stripePlanPerSeatMinimumMonthlyGbpId) {
+    const stripePlanPerSeatMinimumMonthlyGbp = await stripeConnect.plans.create({
+      nickname: 'Per Seat Minimum',
+      currency: "gbp",
+      interval: "month",
+      product: obj.stripeProductWidgetOneId,
+      amount: 400
+    });
+    console.log('CREATED stripePlanPerSeatMinimumMonthlyGbp');
+    obj.stripePlanPerSeatMinimumMonthlyGbpId = stripePlanPerSeatMinimumMonthlyGbp.id
+  }
+
+  if (!obj.stripePerSeatBasicSubscriptionId) {
+    const stripePerSeatBasicSubscription = await stripeConnect.subscriptions.create({
+      customer: obj.stripeCustomerId,
+      items: [{
+        quantity: 3,
+        price: obj.stripePlanPerSeatBasicMonthlyGbpId
+      }],
+      default_payment_method: obj.stripePaymentMethodId
+    });
+    console.log('CREATED stripePerSeatBasicSubscription');
+    obj.stripePerSeatBasicSubscriptionId = stripePerSeatBasicSubscription.id;
+    obj.stripePerSeatBasicSubscriptionLineItemId = stripePerSeatBasicSubscription.items.data[0].id
+  }
+
+  if (!obj.stripePlanBasicMonthlyGbpId) {
+    const stripePlanBasicMonthlyGbp = await stripeConnect.plans.create({
+      currency: "gbp",
+      interval: "month",
+      product: obj.stripeProductWidgetOneId,
+      amount: 1000
+    });
+    console.log('CREATED stripePlanBasicMonthlyGbp');
+    obj.stripePlanBasicMonthlyGbpId = stripePlanBasicMonthlyGbp.id
+  }
+
+  if (!obj.stripePlanBasicYearlyGbpId) {
+    const stripePlanBasicYearlyGbp = await stripeConnect.plans.create({
+      currency: "gbp",
+      interval: "month",
+      product: obj.stripeProductWidgetOneId,
+      amount: 1000
+    });
+    console.log('CREATED stripePlanBasicYearlyGbp');
+    obj.stripePlanBasicYearlyGbpId = stripePlanBasicYearlyGbp.id
+  }
+
+  if (!obj.stripePlanBasicYearlyGbpId) {
+    const stripePlanBasicMonthlyGbp = await stripeConnect.plans.create({
+      currency: "gbp",
+      interval: "year",
+      product: obj.stripeProductWidgetOneId,
+      amount: 10000
+    });
+    console.log('CREATED stripePlanBasicMonthlyGbp');
+    obj.stripePlanBasicYearlyGbpId = stripePlanBasicMonthlyGbp.id
+  }
+
+  if (!obj.stripeBasicSubscriptionId) {
+    const stripeBasicSubscription = await stripeConnect.subscriptions.create({
+      customer: obj.stripeCustomerId,
+      items: [{
+        quantity: 1,
+        price: obj.stripePlanBasicMonthlyGbpId
+      }],
+      default_payment_method: obj.stripePaymentMethodId
+    });
+    console.log('CREATED stripeBasicSubscription');
+    obj.stripeBasicSubscriptionId = stripeBasicSubscription.id;
+    obj.stripeBasicSubscriptionLineItemId = stripeBasicSubscription.items.data[0].id
+  }
+
+  if (!obj.stripeBasicSubscriptionIdTwo) {
+    const stripeBasicSubscription = await stripeConnect.subscriptions.create({
+      customer: obj.stripeCustomerId,
+      items: [{
+        quantity: 1,
+        price: obj.stripePlanBasicMonthlyGbpId
+      }],
+      default_payment_method: obj.stripePaymentMethodId
+    });
+    console.log('CREATED stripeBasicSubscriptionIdTwo');
+    obj.stripeBasicSubscriptionIdTwo = stripeBasicSubscription.id;
+    obj.stripeBasicSubscriptionTwoLineItemId = stripeBasicSubscription.items.data[0].id
+  }
+
+  if (!obj.stripePlanProMonthlyGbpId) {
+    const stripePlanProGbpMonthly = await stripeConnect.plans.create({
+      currency: "gbp",
+      interval: "month",
+      product: obj.stripeProductWidgetOneId,
+      amount: 2500
+    });
+    console.log('CREATED stripePlanProGbpMonthly');
+    obj.stripePlanProMonthlyGbpId = stripePlanProGbpMonthly.id
+  }
+
+  if (!obj.stripeProSubscriptionId) {
+    const stripeProSubscription = await stripeConnect.subscriptions.create({
+      customer: obj.stripeCustomerId,
+      items: [{
+        quantity: 2,
+        price: obj.stripePlanProMonthlyGbpId
+      }],
+      default_payment_method: obj.stripePaymentMethodId
+    });
+    console.log('CREATED stripeProSubscription');
+    obj.stripeProSubscriptionId = stripeProSubscription.id;
+    obj.stripeProSubscriptionLineItemId = stripeProSubscription.items.data[0].id
+  }
+
+  if (!obj.stripePlanBasicMonthlyUsdId) {
+    const stripePlanBasicUsdMonthly = await stripeConnect.plans.create({
+      currency: "usd",
+      interval: "month",
+      product: obj.stripeProductWidgetOneId,
+      amount: 1000
+    });
+    console.log('CREATED stripePlanBasicUsdMonthly');
+    obj.stripePlanBasicMonthlyUsdId = stripePlanBasicUsdMonthly.id
+  }
+
+
+  if (!obj.stripePlanProMonthlyUsdId) {
+    const stripePlanProUsdMonthly = await stripeConnect.plans.create({
+      currency: "usd",
+      interval: "month",
+      product: obj.stripeProductWidgetOneId,
+      amount: 2500
+    });
+    obj.stripePlanProMonthlyUsdId = stripePlanProUsdMonthly.id;
+
+    console.log('CREATED stripeProSubscription');
+    obj.stripePlanProMonthlyUsdId = stripePlanProUsdMonthly.id
+  }
+
+  for (let i = 10; i < 10; i++) {
+    await stripeConnect.invoiceItems.create({
+      customer: obj.stripeCustomerId,
+      subscription: obj.stripeBasicSubscriptionId,
+      amount: 1000,
+      currency: 'gbp',
+      description: 'Charge for past period'
+    });
+
+    const invoice = await stripeConnect.invoices.create({
+      customer: obj.stripeCustomerId,
+      subscription: obj.stripeBasicSubscriptionId,
+      auto_advance: true,
+      collection_method: 'send_invoice',
+      due_date: Math.floor(Date.now() / 1000) + (2592000 * (i + 1)),
+    });
+
+    await stripeConnect.invoices.finalizeInvoice(invoice.id);
+
+    if (i < 5) await stripeConnect.invoices.pay(invoice.id);
+    if (i === 6) await stripeConnect.invoices.voidInvoice(invoice.id);
+    if (i === 8) await stripeConnect.invoices.voidInvoice(invoice.id);
+
+    console.log(`Created and finalized invoice with ID: ${invoice.id}`);
+  }
+
+  return obj;
+}


### PR DESCRIPTION
### Overview

- added create-stripe-test-data function that creates test Stripe account and adds data to test environment variables
- set up Prisma client 

### Standards

- [ ] Updated relevant documentation.
- [ ] Added sufficient tests.
- [ ] Commit log is descriptive and succinct.
- [ ] Tested on multiple browsers (ignore if backend-only change).

