### PR TITLE
fix: renamed reactiveSubscription to reactivateSubscription

### DIFF
--- a/src/subscriptions/index.ts
+++ b/src/subscriptions/index.ts
@@ -140,7 +140,7 @@ export type SubscriptionVersions = {
      *
      * @returns {Promise<void>}
      */
-    reactiveSubscription: (subscriptionUuid: string) => Promise<void>;
+    reactivateSubscription: (subscriptionUuid: string) => Promise<void>;
 
     /**
      *  Incrementing will create unassigned licenses.

--- a/src/subscriptions/v2/index.ts
+++ b/src/subscriptions/v2/index.ts
@@ -17,7 +17,7 @@ export const v2SubscriptionMethods = (request: ApiRequest): SubscriptionVersions
   getPortalLink: (uuid) => request(getUrl(`${baseUrl}/${uuid}/customer-portal`, {}), { method: 'GET' }),
   getCancelSubscriptionLink: (uuid) => request(getUrl(`${baseUrl}/${uuid}/cancelpaymentlink`, {}), { method: 'GET' }),
   getPaymentMethod: (uuid) => request(getUrl(`${baseUrl}/${uuid}/payment-method`, {}), { method: 'GET' }),
-  reactiveSubscription: (uuid) => request(getUrl(`${baseUrl}/${uuid}/reactivate`, {}), { method: 'PUT' }),
+  reactivateSubscription: (uuid) => request(getUrl(`${baseUrl}/${uuid}/reactivate`, {}), { method: 'PUT' }),
   addSeats: (uuid, options) => request(`${baseUrl}/${uuid}/seats`, { method: 'POST', body: JSON.stringify(options) }),
   removeSeats: (uuid, options): Promise<SubscriptionSeatResponse> =>
     request(getUrl(`${baseUrl}/${uuid}/seats`, {}), {


### PR DESCRIPTION
### Overview

- Renamed reactiveSubscription to reactivateSubscription


### Standards

- [ ] Updated relevant documentation.
- [ ] Added sufficient tests.
- [ ] Commit log is descriptive and succinct.
- [ ] Tested on multiple browsers (ignore if backend-only change).

