### PR TITLE
fix: added missing filter params to get-all-licenses method

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -13,7 +13,7 @@ sidebar_position: 2
 
 ### Licenses
 
-- `getAll` now supports cursor based pagination, licenses can also be filtered by `status` and `subscriptionUuid`
+- `getAll` now supports cursor based pagination, licenses can also be filtered by `status`, `subscriptionUuid`, `planUuid`, `productUuid`, and `granteeId`
 - `getOne` and `getForGranteeId` now offer an `expand` option to expand certain properties (e.g. `plan` etc)
 - `getForPurchaser` no longer offers `cancelLink` as an option
 - `getUsage` has been deprecated

--- a/docs/docs/licenses/get-all.md
+++ b/docs/docs/licenses/get-all.md
@@ -28,6 +28,9 @@ _Type:_ `GetLicenseOptions`
 | cursor           | string | Cursor value, used for pagination                           | ❌        |
 | take             | string | The amount of licenses to fetch                             | ❌        |
 | subscriptionUuid | string | The UUID of the subscription to filter by                   | ❌        |
+| granteeId        | string | The grantee ID to filter by                                 | ❌        |
+| planUuid         | string | The UUID of the plan to filter by                           | ❌        |
+| productUuid      | string | The UUID of the product to filter by                        | ❌        |
 
 ## Return Type
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,9 @@ export type GetLicenseOptions = {
   cursor?: string;
   take?: string;
   subscriptionUuid?: string;
+  granteeId?: string;
+  planUuid?: string;
+  productUuid?: string;
 };
 
 export type GetPurchasersLicensesOptions = {


### PR DESCRIPTION
### Overview

- Added missing get-all-licenses query params

### Standards

- [ ] Updated relevant documentation.
- [ ] Added sufficient tests.
- [ ] Commit log is descriptive and succinct.
- [ ] Tested on multiple browsers (ignore if backend-only change).

