### PR TITLE
Fix/get subscriptions sort

### DIFF
--- a/docs/docs/subscriptions/get-all.md
+++ b/docs/docs/subscriptions/get-all.md
@@ -22,13 +22,16 @@ const subscription = await salable.subscriptions.getAll();
 
 _Type:_ `GetSubscriptionOptions`
 
-| Option | Type     | Description                                                               | Required |
-| ------ | -------- | ------------------------------------------------------------------------- | -------- |
-| status | string   | The status of the subscription, e.g. "ACTIVE" "CANCELED"                  | ❌       |
-| email  | string   | The email of who purchased the subscription                               | ❌       |
-| cursor | string   | Cursor value, used for pagination                                         | ❌       |
-| take   | string   | The amount of subscriptions to fetch. Default: `20`                       | ❌       |
-| expand | string[] | Specify which properties to expand. e.g `{ expand: ['product', 'plan'] }` | ❌       |
+| Option      | Type   | Description                                                             | Required |
+|-------------| ------ |-------------------------------------------------------------------------| -------- |
+| status      | string | The status of the subscription, e.g. "ACTIVE" "CANCELED"                | ❌       |
+| email       | string | The email of who purchased the subscription                             | ❌       |
+| cursor      | string | Cursor value, used for pagination                                       | ❌       |
+| take        | string | The amount of subscriptions to fetch. Default: `20`                     | ❌       |
+| productUuid | string | Filter subscriptions by product                                         | ❌       |
+| planUuid    | string | Filter subscriptions by plan                                            | ❌       |
+| sort             | string | Sorts by expiryDate field. Default (`'asc'`). Enum: `'asc'` \| `'desc'` | ❌       |
+
 
 ## Return Type
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@salable/node-sdk",
-  "version": "4.0.0-beta.2",
+  "version": "4.0.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@salable/node-sdk",
-      "version": "4.0.0-beta.2",
+      "version": "4.0.0-beta.6",
       "license": "MIT",
       "devDependencies": {
         "@aws-sdk/client-kms": "^3.682.0",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "pre-commit": "lint-staged",
     "lint": "eslint . -c eslint.config.mjs",
     "lint:fix": "eslint . -c eslint.config.mjs --fix",
-    "test": "jest --passWithNoTests --runInBand",
-    "test:globalCoverage": "jest --coverage --passWithNoTests --runInBand",
-    "test:coverage": "jest --coverage --changedSince=origin/main --passWithNoTests --runInBand",
+    "test": "jest --passWithNoTests",
+    "test:globalCoverage": "jest --coverage --passWithNoTests",
+    "test:coverage": "jest --coverage --changedSince=origin/main --passWithNoTests",
     "build": "rollup -c",
     "preversion": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "pre-commit": "lint-staged",
     "lint": "eslint . -c eslint.config.mjs",
     "lint:fix": "eslint . -c eslint.config.mjs --fix",
-    "test": "jest --passWithNoTests",
+    "test": "jest --passWithNoTests --runInBand",
     "test:globalCoverage": "jest --coverage --passWithNoTests",
     "test:coverage": "jest --coverage --changedSince=origin/main --passWithNoTests",
     "build": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "lint": "eslint . -c eslint.config.mjs",
     "lint:fix": "eslint . -c eslint.config.mjs --fix",
     "test": "jest --passWithNoTests --runInBand",
-    "test:globalCoverage": "jest --coverage --passWithNoTests",
-    "test:coverage": "jest --coverage --changedSince=origin/main --passWithNoTests",
+    "test:globalCoverage": "jest --coverage --passWithNoTests --runInBand",
+    "test:coverage": "jest --coverage --changedSince=origin/main --passWithNoTests --runInBand",
     "build": "rollup -c",
     "preversion": "npm run build"
   },

--- a/src/subscriptions/index.ts
+++ b/src/subscriptions/index.ts
@@ -10,7 +10,7 @@ import {
   ApiRequest,
   TVersion,
   Version,
-  sortOrder
+  SortOrder
 } from '../types';
 import { v2SubscriptionMethods } from './v2';
 
@@ -25,7 +25,7 @@ export type SubscriptionVersions = {
      *
      * @returns {Promise<PaginatedSubscription>} The data of the subscription requested
      */
-    getAll: (options?: { status?: SubscriptionStatus; email?: string; cursor?: string; take?: string; expand?: string[], sort?: sortOrder, productUuid?: string, planUuid?: string}) => Promise<PaginatedSubscription>;
+    getAll: (options?: { status?: SubscriptionStatus; email?: string; cursor?: string; take?: string; expand?: string[], sort?: SortOrder, productUuid?: string, planUuid?: string}) => Promise<PaginatedSubscription>;
 
     /**
      *  Retrieves the subscription data based on the UUID. By default, the response does not contain any relational data. If you want to expand the relational data, you can do so with the `expand` query parameter.

--- a/src/subscriptions/index.ts
+++ b/src/subscriptions/index.ts
@@ -1,4 +1,17 @@
-import { PaginatedSubscription, Subscription, PaginatedSubscriptionInvoice, SubscriptionPaymentLink, SubscriptionPaymentMethod, SubscriptionPlan, SubscriptionSeat, SubscriptionStatus, ApiRequest, TVersion, Version } from '../types';
+import {
+  PaginatedSubscription,
+  Subscription,
+  PaginatedSubscriptionInvoice,
+  SubscriptionPaymentLink,
+  SubscriptionPaymentMethod,
+  SubscriptionPlan,
+  SubscriptionSeat,
+  SubscriptionStatus,
+  ApiRequest,
+  TVersion,
+  Version,
+  sortOrder
+} from '../types';
 import { v2SubscriptionMethods } from './v2';
 
 export type SubscriptionVersions = {
@@ -12,7 +25,7 @@ export type SubscriptionVersions = {
      *
      * @returns {Promise<PaginatedSubscription>} The data of the subscription requested
      */
-    getAll: (options?: { status?: SubscriptionStatus; email?: string; cursor?: string; take?: string; expand?: string[] }) => Promise<PaginatedSubscription>;
+    getAll: (options?: { status?: SubscriptionStatus; email?: string; cursor?: string; take?: string; expand?: string[], sort?: sortOrder, productUuid?: string, planUuid?: string}) => Promise<PaginatedSubscription>;
 
     /**
      *  Retrieves the subscription data based on the UUID. By default, the response does not contain any relational data. If you want to expand the relational data, you can do so with the `expand` query parameter.

--- a/src/subscriptions/v2/subscriptions-v2.test.ts
+++ b/src/subscriptions/v2/subscriptions-v2.test.ts
@@ -483,9 +483,9 @@ const generateTestData = async () => {
 
   await prismaClient.subscription.create({
     data: {
-      lineItemIds: [stripeEnvs.basicSubscriptionTwoLineItemId],
-      paymentIntegrationSubscriptionId: stripeEnvs.basicSubscriptionTwoId,
       uuid: basicSubscriptionUuid,
+      paymentIntegrationSubscriptionId: stripeEnvs.basicSubscriptionTwoId,
+      lineItemIds: [stripeEnvs.basicSubscriptionTwoLineItemId],
       email: testEmail,
       type: 'salable',
       status: 'ACTIVE',
@@ -519,9 +519,9 @@ const generateTestData = async () => {
 
   await prismaClient.subscription.create({
     data: {
-      lineItemIds: [stripeEnvs.proSubscriptionLineItemId],
-      paymentIntegrationSubscriptionId: stripeEnvs.proSubscriptionId,
       uuid: proSubscriptionUuid,
+      paymentIntegrationSubscriptionId: stripeEnvs.proSubscriptionId,
+      lineItemIds: [stripeEnvs.proSubscriptionLineItemId],
       email: testEmail,
       type: 'salable',
       status: 'ACTIVE',

--- a/src/subscriptions/v2/subscriptions-v2.test.ts
+++ b/src/subscriptions/v2/subscriptions-v2.test.ts
@@ -77,8 +77,6 @@ describe('Subscriptions V2 Tests', () => {
       last: expect.any(String),
       data: expect.arrayContaining([{ ...subscriptionSchema, plan: planSchema }]),
     });
-    console.log('stripeEnvs', stripeEnvs);
-    console.log('dataWithSearchParams', dataWithSearchParams)
     expect(dataWithSearchParams.data.length).toEqual(2);
     expect(dataWithSearchParams.data).toEqual(
       expect.arrayContaining([

--- a/src/subscriptions/v2/subscriptions-v2.test.ts
+++ b/src/subscriptions/v2/subscriptions-v2.test.ts
@@ -166,6 +166,39 @@ describe('Subscriptions V2 Tests', () => {
   });
 
   it('cancel: Should successfully cancel the subscription', async () => {
+    await prismaClient.subscription.upsert({
+      where: {
+        paymentIntegrationSubscriptionId: stripeEnvs.basicSubscriptionId,
+      },
+      update: {
+        uuid: subscriptionUuid,
+        email: testEmail,
+        type: 'salable',
+        status: 'ACTIVE',
+        organisation: testUuids.organisationId,
+        license: { connect: [{ uuid: licenseUuid }] },
+        product: { connect: { uuid: testUuids.productUuid } },
+        plan: { connect: { uuid: testUuids.paidPlanUuid } },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        expiryDate: new Date(Date.now() + 31536000000),
+      },
+      create: {
+        uuid: subscriptionUuid,
+        lineItemIds: [stripeEnvs.basicSubscriptionLineItemId],
+        paymentIntegrationSubscriptionId: stripeEnvs.basicSubscriptionId,
+        email: testEmail,
+        type: 'salable',
+        status: 'ACTIVE',
+        organisation: testUuids.organisationId,
+        license: { connect: [{ uuid: licenseUuid }] },
+        product: { connect: { uuid: testUuids.productUuid } },
+        plan: { connect: { uuid: testUuids.paidPlanUuid } },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        expiryDate: new Date(Date.now() + 31536000000),
+      },
+    });
     const data = await salable.subscriptions.cancel(subscriptionUuid, { when: 'now' });
 
     expect(data).toBeUndefined();
@@ -478,40 +511,6 @@ const generateTestData = async () => {
         },
       ],
       endTime: getEndTime(1, 'years'),
-    },
-  });
-
-  await prismaClient.subscription.upsert({
-    where: {
-      paymentIntegrationSubscriptionId: stripeEnvs.basicSubscriptionId,
-    },
-    update: {
-      uuid: subscriptionUuid,
-      email: testEmail,
-      type: 'salable',
-      status: 'ACTIVE',
-      organisation: testUuids.organisationId,
-      license: { connect: [{ uuid: licenseUuid }] },
-      product: { connect: { uuid: testUuids.productUuid } },
-      plan: { connect: { uuid: testUuids.paidPlanUuid } },
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      expiryDate: new Date(Date.now() + 31536000000),
-    },
-    create: {
-      uuid: subscriptionUuid,
-      lineItemIds: [stripeEnvs.basicSubscriptionLineItemId],
-      paymentIntegrationSubscriptionId: stripeEnvs.basicSubscriptionId,
-      email: testEmail,
-      type: 'salable',
-      status: 'ACTIVE',
-      organisation: testUuids.organisationId,
-      license: { connect: [{ uuid: licenseUuid }] },
-      product: { connect: { uuid: testUuids.productUuid } },
-      plan: { connect: { uuid: testUuids.paidPlanUuid } },
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      expiryDate: new Date(Date.now() + 31536000000),
     },
   });
 

--- a/src/subscriptions/v2/subscriptions-v2.test.ts
+++ b/src/subscriptions/v2/subscriptions-v2.test.ts
@@ -69,7 +69,7 @@ describe('Subscriptions V2 Tests', () => {
       expand: ['plan'],
       sort: 'desc',
       productUuid: testUuids.productUuid,
-      planUuid: testUuids.paidPlanUuidTwo
+      planUuid: testUuids.paidPlanTwoUuid
     });
 
     expect(dataWithSearchParams).toEqual({
@@ -85,7 +85,7 @@ describe('Subscriptions V2 Tests', () => {
           productUuid: testUuids.productUuid,
           plan: {
             ...planSchema,
-            uuid: testUuids.paidPlanUuidTwo
+            uuid: testUuids.paidPlanTwoUuid
           },
         }),
       ]),
@@ -384,7 +384,7 @@ const generateTestData = async () => {
       type: 'user',
       uuid: licenseUuid,
       metadata: undefined,
-      plan: { connect: { uuid: testUuids.paidPlanUuidTwo } },
+      plan: { connect: { uuid: testUuids.paidPlanTwoUuid } },
       product: { connect: { uuid: testUuids.productUuid } },
       startTime: undefined,
       capabilities: [
@@ -492,7 +492,7 @@ const generateTestData = async () => {
       organisation: testUuids.organisationId,
       license: { connect: [{ uuid: licenseUuid }] },
       product: { connect: { uuid: testUuids.productUuid } },
-      plan: { connect: { uuid: testUuids.paidPlanUuidTwo } },
+      plan: { connect: { uuid: testUuids.paidPlanTwoUuid } },
       createdAt: new Date(),
       updatedAt: new Date(),
       expiryDate: new Date(Date.now() + 31536000000),
@@ -510,7 +510,7 @@ const generateTestData = async () => {
       organisation: testUuids.organisationId,
       license: { connect: [{ uuid: licenseUuid }] },
       product: { connect: { uuid: testUuids.productUuid } },
-      plan: { connect: { uuid: testUuids.paidPlanUuidTwo } },
+      plan: { connect: { uuid: testUuids.paidPlanTwoUuid } },
       createdAt: new Date(),
       updatedAt: new Date(),
       expiryDate: new Date(Date.now() + 31536000000),

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type ApiRequest = <T>(input: string | URL | Request, init: RequestInit | 
 export type Status = 'ACTIVE' | 'CANCELED';
 export type ProductStatus = 'ACTIVE' | 'DEPRECATED';
 export type LicenseStatus = 'ACTIVE' | 'CANCELED' | 'EVALUATION' | 'SCHEDULED' | 'TRIALING' | 'INACTIVE';
-export type sortOrder = 'asc' | 'desc';
+export type SortOrder = 'asc' | 'desc';
 
 export type SearchParamOptions = Record<string, string | string[] | number | boolean>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export type ApiRequest = <T>(input: string | URL | Request, init: RequestInit | 
 export type Status = 'ACTIVE' | 'CANCELED';
 export type ProductStatus = 'ACTIVE' | 'DEPRECATED';
 export type LicenseStatus = 'ACTIVE' | 'CANCELED' | 'EVALUATION' | 'SCHEDULED' | 'TRIALING' | 'INACTIVE';
+export type sortOrder = 'asc' | 'desc';
 
 export type SearchParamOptions = Record<string, string | string[] | number | boolean>;
 

--- a/test-utils/scripts/create-test-data.ts
+++ b/test-utils/scripts/create-test-data.ts
@@ -14,7 +14,7 @@ export type TestDbData = {
   productTwoUuid: string;
   freeMonthlyPlanUuid: string;
   paidPlanUuid: string;
-  paidPlanUuidTwo: string;
+  paidPlanTwoUuid: string;
   perSeatPaidPlanUuid: string;
   paidYearlyPlanUuid: string;
   freeYearlyPlanUuid: string;
@@ -39,7 +39,7 @@ const productUuid = '29c9a7c8-9a41-4e87-9e7e-7c62d293c131';
 const productTwoUuid = '2e0ac383-ee7e-44ba-90cb-ab3eabd56722';
 const freeMonthlyPlanUuid = '5a866dba-20c9-466f-88ac-e05c8980c90b';
 const paidPlanUuid = '351eefac-9b21-4299-8cde-302249d6fb1e';
-const paidPlanUuidTwo = 'bcd626d6-9507-42dd-9105-40c149853403';
+const paidPlanTwoUuid = 'bcd626d6-9507-42dd-9105-40c149853403';
 const perSeatPaidPlanUuid = 'cee50a36-c012-4a78-8e1a-b2bab93830ba';
 const paidYearlyPlanUuid = '111eefac-9b21-4299-8cde-302249d6f111';
 const freeYearlyPlanUuid = '22266dba-20c9-466f-88ac-e05c8980c222';
@@ -63,7 +63,7 @@ export const testUuids: TestDbData = {
   productTwoUuid,
   freeMonthlyPlanUuid,
   paidPlanUuid,
-  paidPlanUuidTwo,
+  paidPlanTwoUuid,
   perSeatPaidPlanUuid,
   paidYearlyPlanUuid,
   freeYearlyPlanUuid,
@@ -416,7 +416,7 @@ export default async function createTestData(stripeEnvs: StripeEnvsTypes) {
       name: 'Basic Monthly Plan Two Name',
       description: 'Basic Monthly Plan Two description',
       displayName: 'Basic Monthly Plan Two Display Name',
-      uuid: paidPlanUuidTwo,
+      uuid: paidPlanTwoUuid,
       product: { connect: { uuid: product.uuid } },
       status: 'ACTIVE',
       trialDays: 0,
@@ -434,7 +434,7 @@ export default async function createTestData(stripeEnvs: StripeEnvsTypes) {
         create: product.currencies.map((c) => ({
           currency: { connect: { uuid: c.currencyUuid } },
           price: 1000,
-          paymentIntegrationPlanId: c.currency.shortName === 'GBP' ? stripeEnvs.planBasicMonthlyGbpId : stripeEnvs.planBasicMonthlyUsdId,
+          paymentIntegrationPlanId: c.currency.shortName === 'GBP' ? stripeEnvs.planTwoBasicMonthlyGbpId : stripeEnvs.planTwoBasicMonthlyUsdId,
         })),
       },
       features: {

--- a/test-utils/stripe/create-stripe-test-data.ts
+++ b/test-utils/stripe/create-stripe-test-data.ts
@@ -12,6 +12,7 @@ export interface StripeEnvsTypes {
   customerId: string;
   productWidgetOneId: string;
   planBasicMonthlyGbpId: string;
+  planTwoBasicMonthlyGbpId: string;
   planBasicYearlyGbpId: string;
   planPerSeatBasicMonthlyGbpId: string;
   planUsageProMonthlyGbpId: string;
@@ -20,15 +21,14 @@ export interface StripeEnvsTypes {
   usageBasicSubscriptionId: string;
   planProMonthlyGbpId: string;
   planBasicMonthlyUsdId: string;
+  planTwoBasicMonthlyUsdId: string;
   planProMonthlyUsdId: string;
   basicSubscriptionId: string;
   basicSubscriptionTwoId: string;
   basicSubscriptionThreeId: string;
-  basicSubscriptionFourId: string;
   basicSubscriptionLineItemId: string;
   basicSubscriptionTwoLineItemId: string;
   basicSubscriptionThreeLineItemId: string;
-  basicSubscriptionFourLineItemId: string;
   perSeatBasicSubscriptionId: string;
   perSeatBasicSubscriptionLineItemId: string;
   proSubscriptionId: string;
@@ -135,6 +135,12 @@ export default async function createStripeData(): Promise<StripeEnvsTypes> {
     product: stripeProductWidgetOne.id,
     amount: 10000,
   });
+  const stripePlanTwoBasicMonthlyGbp = await stripeConnect.plans.create({
+    currency: 'gbp',
+    interval: 'month',
+    product: stripeProductWidgetOne.id,
+    amount: 10000,
+  });
   const stripePlanBasicYearlyGbp = await stripeConnect.plans.create({
     currency: 'gbp',
     interval: 'year',
@@ -153,7 +159,7 @@ export default async function createStripeData(): Promise<StripeEnvsTypes> {
     customer: stripeCustomer.id,
     items: [{
       quantity: 1,
-      price: stripePlanBasicMonthlyGbp.id,
+      price: stripePlanTwoBasicMonthlyGbp.id,
     }],
     default_payment_method: stripePaymentMethod.id,
   });
@@ -161,15 +167,7 @@ export default async function createStripeData(): Promise<StripeEnvsTypes> {
     customer: stripeCustomer.id,
     items: [{
       quantity: 1,
-      price: stripePlanBasicMonthlyGbp.id,
-    }],
-    default_payment_method: stripePaymentMethod.id,
-  });
-  const stripeBasicSubscriptionFour = await stripeConnect.subscriptions.create({
-    customer: stripeCustomer.id,
-    items: [{
-      quantity: 1,
-      price: stripePlanBasicMonthlyGbp.id,
+      price: stripePlanTwoBasicMonthlyGbp.id,
     }],
     default_payment_method: stripePaymentMethod.id,
   });
@@ -188,6 +186,12 @@ export default async function createStripeData(): Promise<StripeEnvsTypes> {
     default_payment_method: stripePaymentMethod.id
   });
   const stripePlanBasicUsdMonthly = await stripeConnect.plans.create({
+    currency: 'usd',
+    interval: 'month',
+    product: stripeProductWidgetOne.id,
+    amount: 1000,
+  });
+  const stripePlanTwoBasicUsdMonthly = await stripeConnect.plans.create({
     currency: 'usd',
     interval: 'month',
     product: stripeProductWidgetOne.id,
@@ -234,6 +238,7 @@ export default async function createStripeData(): Promise<StripeEnvsTypes> {
     planPerSeatRangeMonthlyGbpId: stripePlanPerSeatRangeMonthlyGbp.id,
     planPerSeatMinimumMonthlyGbpId: stripePlanPerSeatMinimumMonthlyGbp.id,
     planBasicMonthlyGbpId: stripePlanBasicMonthlyGbp.id,
+    planTwoBasicMonthlyGbpId: stripePlanTwoBasicMonthlyGbp.id,
     planBasicYearlyGbpId: stripePlanBasicYearlyGbp.id,
     perSeatBasicSubscriptionId: stripePerSeatBasicSubscription.id,
     perSeatBasicSubscriptionLineItemId: stripePerSeatBasicSubscription.items.data[0].id,
@@ -243,10 +248,9 @@ export default async function createStripeData(): Promise<StripeEnvsTypes> {
     basicSubscriptionTwoLineItemId: stripeBasicSubscriptionTwo.items.data[0].id,
     basicSubscriptionThreeId: stripeBasicSubscriptionThree.id,
     basicSubscriptionThreeLineItemId: stripeBasicSubscriptionThree.items.data[0].id,
-    basicSubscriptionFourId: stripeBasicSubscriptionFour.id,
-    basicSubscriptionFourLineItemId: stripeBasicSubscriptionFour.items.data[0].id,
     planProMonthlyGbpId: stripePlanProGbpMonthly.id,
     planBasicMonthlyUsdId: stripePlanBasicUsdMonthly.id,
+    planTwoBasicMonthlyUsdId: stripePlanTwoBasicUsdMonthly.id,
     planProMonthlyUsdId: stripePlanProUsdMonthly.id,
     proSubscriptionId: stripeProSubscription.id,
     proSubscriptionLineItemId: stripeProSubscription.items.data[0].id,


### PR DESCRIPTION
### Overview

- added `sort`, `planUuid` and `productUuid` options to get all subscriptions
- added a new plan in the stripe test data to reference in the get all subscriptions filter by plan test

### Collaborators

<!-- Who did you collaborate with to get this PR ready? -->

### Standards

- [ ] Updated relevant documentation.
- [ ] Added sufficient tests.
- [ ] Commit log is descriptive and succinct.
- [ ] Tested on multiple browsers (ignore if backend-only change).

### Considerations

<!-- Is there anything about your implementation that you think the reviewer
should be made aware of? What should they take into consideration when
looking at this code? -->
