### PR TITLE
feat(SD-2145): added required webhook emitters tables

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -703,7 +703,7 @@ model CouponsOnSubscriptions {
 }
 
 model WebhookDestinationEventType {
-  uuid            String             @id @default(uuid())
+  uuid            String             @id @default(uuid(7))
   event           String
   destinationUuid String
   destination     WebhookDestination @relation(fields: [destinationUuid], references: [uuid], onDelete: Cascade)
@@ -715,7 +715,7 @@ model WebhookDestinationEventType {
 }
 
 model WebhookDestination {
-  uuid         String                        @id @default(uuid())
+  uuid         String                        @id @default(uuid(7))
   url          String
   organisation String
   eventTypes   WebhookDestinationEventType[]
@@ -726,7 +726,7 @@ model WebhookDestination {
 }
 
 model WebhookEvent {
-  uuid              String                    @id @default(uuid())
+  uuid              String                    @id @default(uuid(7))
   organisation      String
   type              String
   payload           Json
@@ -736,7 +736,7 @@ model WebhookEvent {
 }
 
 model WebhookDestinationEvent {
-  uuid            String                @id @default(uuid())
+  uuid            String                @id @default(uuid(7))
   eventUuid       String
   event           WebhookEvent          @relation(fields: [eventUuid], references: [uuid], onDelete: Cascade)
   destinationUuid String
@@ -756,7 +756,7 @@ enum WebhookEventAttemptStatus {
 }
 
 model WebhookEventAttempt {
-  uuid                 String                    @id @default(uuid())
+  uuid                 String                    @id @default(uuid(7))
   destinationEventUuid String
   destinationEvent     WebhookDestinationEvent   @relation(fields: [destinationEventUuid], references: [uuid], onDelete: Cascade)
   attempt              Int

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -681,6 +681,16 @@ model CouponsOnPlans {
   @@index([planUuid])
 }
 
+model WebhookEvents {
+  uuid      String   @id @default(uuid())
+  objectId  String
+  eventType String
+  reason    String
+  payload   Json
+  isTest    Boolean
+  createdAt DateTime @default(now())
+}
+
 model CouponsOnSubscriptions {
   coupon           Coupon       @relation(fields: [couponUuid], references: [uuid])
   couponUuid       String
@@ -756,14 +766,4 @@ model WebhookEventAttempt {
   updatedAt            DateTime                  @updatedAt
   scheduledAt          DateTime?
   organisation         String
-}
-
-model WebhookEvents {
-  uuid      String   @id @default(uuid())
-  objectId  String
-  eventType String
-  reason    String
-  payload   Json
-  isTest    Boolean
-  createdAt DateTime @default(now())
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -709,6 +709,7 @@ model WebhookDestinationEventType {
   destination     WebhookDestination @relation(fields: [destinationUuid], references: [uuid], onDelete: Cascade)
   createdAt       DateTime           @default(now())
   updatedAt       DateTime           @updatedAt
+  deletedAt       DateTime?
   organisation    String
 
   @@unique([event, destinationUuid])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,9 +31,9 @@ model Product {
   subscriptions                      Subscription[]
   currencies                         CurrenciesOnProduct[]
   updatedAt                          DateTime                        @default(now()) @updatedAt
+  archivedAt                         DateTime?
   isTest                             Boolean                         @default(false)
   coupons                            Coupon[]
-  archivedAt                         DateTime?
 
   @@index([organisation])
   @@index([organisationPaymentIntegrationUuid])
@@ -681,16 +681,6 @@ model CouponsOnPlans {
   @@index([planUuid])
 }
 
-model WebhookEvents {
-  uuid      String   @id @default(uuid())
-  objectId  String
-  eventType String
-  reason    String
-  payload   Json
-  isTest    Boolean
-  createdAt DateTime @default(now())
-}
-
 model CouponsOnSubscriptions {
   coupon           Coupon       @relation(fields: [couponUuid], references: [uuid])
   couponUuid       String
@@ -700,4 +690,80 @@ model CouponsOnSubscriptions {
   @@id([couponUuid, subscriptionUuid])
   @@index([couponUuid])
   @@index([subscriptionUuid])
+}
+
+model WebhookDestinationEventType {
+  uuid            String             @id @default(uuid())
+  event           String
+  destinationUuid String
+  destination     WebhookDestination @relation(fields: [destinationUuid], references: [uuid], onDelete: Cascade)
+  createdAt       DateTime           @default(now())
+  updatedAt       DateTime           @updatedAt
+  organisation    String
+
+  @@unique([event, destinationUuid])
+}
+
+model WebhookDestination {
+  uuid         String                        @id @default(uuid())
+  url          String
+  organisation String
+  eventTypes   WebhookDestinationEventType[]
+  secret       Json
+  events       WebhookDestinationEvent[]
+  createdAt    DateTime                      @default(now())
+  updatedAt    DateTime                      @updatedAt
+}
+
+model WebhookEvent {
+  uuid              String                    @id @default(uuid())
+  organisation      String
+  type              String
+  payload           Json
+  destinationEvents WebhookDestinationEvent[]
+  createdAt         DateTime                  @default(now())
+  updatedAt         DateTime                  @updatedAt
+}
+
+model WebhookDestinationEvent {
+  uuid            String                @id @default(uuid())
+  eventUuid       String
+  event           WebhookEvent          @relation(fields: [eventUuid], references: [uuid], onDelete: Cascade)
+  destinationUuid String
+  destination     WebhookDestination    @relation(fields: [destinationUuid], references: [uuid], onDelete: Cascade)
+  attempts        WebhookEventAttempt[]
+  createdAt       DateTime              @default(now())
+  updatedAt       DateTime              @updatedAt
+  organisation    String
+
+  @@unique([eventUuid, destinationUuid])
+}
+
+enum WebhookEventAttemptStatus {
+  SUCCESS
+  ERROR
+  PENDING
+}
+
+model WebhookEventAttempt {
+  uuid                 String                    @id @default(uuid())
+  destinationEventUuid String
+  destinationEvent     WebhookDestinationEvent   @relation(fields: [destinationEventUuid], references: [uuid], onDelete: Cascade)
+  attempt              Int
+  status               WebhookEventAttemptStatus @default(PENDING)
+  message              String?
+  createdAt            DateTime                  @default(now())
+  updatedAt            DateTime                  @updatedAt
+  scheduledAt          DateTime?
+  organisation         String
+}
+
+model WebhookEvents {
+  uuid      String   @id @default(uuid())
+  objectId  String
+  eventType String
+  reason    String
+  payload   Json
+  isTest    Boolean
+  createdAt DateTime @default(now())
 }


### PR DESCRIPTION
### JIRA Ticket(s):

- SD-2145

### Overview

- Added required webhook emitters tables
- App PR: https://github.com/Salable/app/pull/908
- API PR:  https://bitbucket.org/adaptavistlabs/salable-api/pull-requests/645
- Seeding CLI PR: https://github.com/Salable/salable-seeding-and-migrations-cli/pull/43

### Standards

- [ ] Updated relevant documentation.
- [ ] Added sufficient tests.
- [ ] Commit log is descriptive and succinct.
- [ ] Tested on multiple browsers (ignore if backend-only change).

