### PR TITLE
feat: add sentCount column to webhook event attempt table

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -767,4 +767,5 @@ model WebhookEventAttempt {
   updatedAt            DateTime                  @updatedAt
   scheduledAt          DateTime?
   organisation         String
+  sentCount            Int                       @default(0)
 }

--- a/src/subscriptions/v2/subscriptions-v2.test.ts
+++ b/src/subscriptions/v2/subscriptions-v2.test.ts
@@ -40,7 +40,7 @@ describe('Subscriptions V2 Tests', () => {
       owner: 'example',
       granteeId: 'test-grantee-id',
       status: 'ACTIVE',
-      expiryDate: '2025-07-06T12:00:00.000Z',
+      expiryDate: '2045-07-06T12:00:00.000Z',
     });
 
     expect(data).toEqual(expect.objectContaining(subscriptionSchema));


### PR DESCRIPTION
### Overview

- Add sentCount column to webhook event attempt table
- APP PR: https://github.com/Salable/app/pull/925
- API PR: https://bitbucket.org/adaptavistlabs/salable-api/pull-requests/648
- Seeding CLI PR: https://github.com/Salable/salable-seeding-and-migrations-cli/pull/45

### Standards

- [ ] Updated relevant documentation.
- [ ] Added sufficient tests.
- [ ] Commit log is descriptive and succinct.
- [ ] Tested on multiple browsers (ignore if backend-only change).

